### PR TITLE
Do not auto commit all changes to existing files

### DIFF
--- a/.github/workflows/generate-lists.yml
+++ b/.github/workflows/generate-lists.yml
@@ -44,6 +44,8 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git checkout lists
         mv data/* .
+        git status
+        ls
         # If the sanctioned addresses have been updated, or if there is no checksum
         # or XML bzip file, bzip the file and check it into git along with the checksum.
         if git status sanctioned_addresses_* --porcelain | grep -q '^ M' || \
@@ -54,7 +56,8 @@ jobs:
           git add sdn_advanced.xml.bz2
         fi
         git add sanctioned_addresses_* -f
-        git commit -m "Automatically updated lists: $(date)" -a || true
+        git status
+        git commit -m "Automatically updated lists: $(date)" || true
     - name: Push changes
       uses: ad-m/github-push-action@9a2e3c14aaecf56d5816dc3a54514f82050820b2 # master
       with:


### PR DESCRIPTION
The checksum file (already checked into git) is automatically committed every time it changes since we were passing the -a param to git commit.  The zip file (already checked into git) was only being modified if the addresses had changed.  So even though that file was checked into git, we weren't adding the changes, since there weren't any to add.

We don't need the -a parameter since we are explicitly adding everything we need.

Also add some useful debug statements for future runs.