### PR TITLE
Add retry logic to sanctions list download

### DIFF
--- a/.github/workflows/generate-lists.yml
+++ b/.github/workflows/generate-lists.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Download the sdn_advanced.xml file
       uses: wei/wget@c15e476d1463f4936cb54f882170d9d631f1aba5 # v1
       with:
-        args: https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml
+        args: --tries=5 --wait=60 https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml
     - name: Generate TXT and JSON files for all assets
       run: |
         mkdir data


### PR DESCRIPTION
Try 5 times with 60 seconds between.

We're getting some 403s when we try to download the list, which appear to be transient. So hopefully this should help.

Slack thread: https://bravesoftware.slack.com/archives/C074C0V92ET/p1727741399024959