### PR TITLE
Use real wget

### DIFF
--- a/.github/workflows/generate-lists.yml
+++ b/.github/workflows/generate-lists.yml
@@ -31,9 +31,8 @@ jobs:
         sudo apt-get install -y google-chrome-stable chromium-chromedriver
         pip install selenium webdriver-manager
     - name: Download the sdn_advanced.xml file
-      uses: wei/wget@c15e476d1463f4936cb54f882170d9d631f1aba5 # v1
-      with:
-        args: --tries=5 --wait=60 https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml
+      run: |
+        wget --tries=5 --wait=60 https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml
     - name: Generate TXT and JSON files for all assets
       run: |
         mkdir data


### PR DESCRIPTION
Instead of wei/wget. We already install the real wget earlier in the script via sudo apt install. Let's use that instead, it supports --wait. I ran a script on this branch and it succeeded: https://github.com/brave-intl/ofac-sanctioned-digital-currency-addresses/actions/runs/11130103425